### PR TITLE
Remove dev comment from gh workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,6 +1,3 @@
-# This needs the following setting:
-# Setttings > Actions > General > Workflow permissions
-# change to "Read and write permissions"
 name: github pages
 
 on:


### PR DESCRIPTION
This comment was just in there while we developed the action, we can remove it now.
