### PR TITLE
fix: gh-pages.yml permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We had the error on `gh-pages` actions workflow.
This might fix this.

Source: https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-first-deployment-with-github_token

> If the action fails to push the commit or tag with the following error:
>
> ```shell
> /usr/bin/git push origin gh-pages
> remote: Write access to repository not granted.
> fatal: unable to access 'https://github.com/username/repository.git/': The requested URL returned error: 403
> Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"
> ```
>
> Please add the `write` permission to the `permissions.contents` in a workflow/job.
>
> ```yml
> permissions:
>   contents: write
> ```