### PR TITLE
Update repository mention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# .gitignore for www.rust-bitcoin.org
+# .gitignore for rust-bitcoin.github.io
 
 # web build
 site/public

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Website source for `www.rust-bitcoin.org`
+# Website source for `https://rust-bitcoin.org`
 
 While the website is deployed at rust-bitcoin.org there are still missing parts such as the cookbook.
 We will be happy to receive contributions adding interesting examples.


### PR DESCRIPTION
We are now hosting the repository at rust-bitcoin.github.io and have archived the old www.rust-bitcoin.org

Update a couple of mentions of the old repository.

Close: #10