### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Website source for `www.rust-bitcoin.org`
 
-While the website is deployed at rust-bitcoin.org there are still missing parts such as the cookbook.
-We will be happy to receive contributions adding interesting examples.
-
 Website for the rust-bitcoin ecosystem. The site is built using [hugo](https://gohugo.io/) and the
 [nightfall](https://themes.gohugo.io/themes/hugo-theme-nightfall/) theme.
 
 Includes a cookbook built with [mdbook](https://rust-lang.github.io/mdBook/).
+
+Contributions most welcome and appreciated. If you come here looking for how to do something and
+find it missing please consider contributing an example or raising an issue.
+
+## Current rust-bitcoin version
+
+This cookbook is currently based on [rust-bitcoin `v0.31.1`](https://docs.rs/bitcoin/0.31.1/bitcoin/index.html)
 
 ## License
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -5,7 +5,9 @@
 Welcome to the `rust-bitcoin` cookbook!
 This cookbook is designed to provide readers with a
 comprehensive understanding of `rust-bitcoin` and its key features.
-Don't forget to check [`rust-bitcoin`'s documentation](https://docs.rs/bitcoin)
+
+Cookbook currently depends on `rust-bitcoin` version [`v0.31.1`](https://docs.rs/bitcoin/0.31.1/bitcoin/index.html).
+This may not be the [latest available version](https://docs.rs/bitcoin) of `rust-bitcoin`.
 
 ## How to contribute
 


### PR DESCRIPTION
The site is up and running now, lets update the readme to reflect this.

While we are at it mention the fact that the cookbook depends on a specific version of `rust-bitcoin` and that this may not be the latest available version. Link to both.