### PR TITLE
Use link to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Website source for `https://rust-bitcoin.org`
+# Website source for https://rust-bitcoin.org
 
 Website for the rust-bitcoin ecosystem. The site is built using [hugo](https://gohugo.io/) and the
 [nightfall](https://themes.gohugo.io/themes/hugo-theme-nightfall/) theme.


### PR DESCRIPTION
A link is more useful than a code block for the URL of the website, then readers of the readme can click on it.