### PR TITLE
Fix example spend amount

### DIFF
--- a/cookbook/src/tx_segwit-v0.md
+++ b/cookbook/src/tx_segwit-v0.md
@@ -204,7 +204,7 @@ fn main() {
     let sighash_type = EcdsaSighashType::All;
     let mut sighasher = SighashCache::new(&mut unsigned_tx);
     let sighash = sighasher
-        .p2wpkh_signature_hash(input_index, &dummy_utxo.script_pubkey, SPEND_AMOUNT, sighash_type)
+        .p2wpkh_signature_hash(input_index, &dummy_utxo.script_pubkey, DUMMY_UTXO_AMOUNT, sighash_type)
         .expect("failed to create sighash");
 
     // Sign the sighash using the secp256k1 library (exported by rust-bitcoin).


### PR DESCRIPTION
In the segwit signing example we are using the incorrect value when creating the signature - we should be using the utxo amount (input amount) not the spend amount (output spend amount).

Also fixed in `rust-bitcoin` PR [#2696](https://github.com/rust-bitcoin/rust-bitcoin).