### PR TITLE
cookbook: Upgrade to latest bitcoin 0.32.0

### DIFF
--- a/cookbook/src/tx_segwit-v0.md
+++ b/cookbook/src/tx_segwit-v0.md
@@ -108,7 +108,7 @@ fn dummy_unspent_transaction_output(wpkh: &WPubkeyHash) -> (OutPoint, TxOut) {
 ```
 
 `dummy_unspent_transaction_output` generates a dummy unspent transaction output (UTXO).
-This is a SegWit V0 P2WPKH (`ScriptBuf::new_v0_p2wpkh`) UTXO with a dummy invalid transaction ID (`txid: Txid::all_zeros()`),
+This is a SegWit V0 P2WPKH (`ScriptBuf::new_p2wpkh`) UTXO with a dummy invalid transaction ID (`txid: Txid::all_zeros()`),
 and a value of the `const DUMMY_UTXO_AMOUNT` that we defined earlier.
 We are using the [`OutPoint`](https://docs.rs/bitcoin/0.31.1/bitcoin/blockdata/transaction/struct.OutPoint.html) struct to represent the transaction output.
 Finally, we return the tuple `(out_point, utxo)`.
@@ -209,10 +209,10 @@ fn main() {
 
     // Sign the sighash using the secp256k1 library (exported by rust-bitcoin).
     let msg = Message::from(sighash);
-    let sig = secp.sign_ecdsa(&msg, &sk);
+    let signature = secp.sign_ecdsa(&msg, &sk);
 
     // Update the witness stack.
-    let signature = bitcoin::ecdsa::Signature { sig, hash_ty: EcdsaSighashType::All };
+    let signature = bitcoin::ecdsa::Signature { signature, sighash_type };
     let pk = sk.public_key(&secp);
     *sighasher.witness_mut(input_index).unwrap() = Witness::p2wpkh(&signature, &pk);
 
@@ -264,7 +264,7 @@ Inside the [`TxOut`](https://docs.rs/bitcoin/0.31.1/bitcoin/blockdata/transactio
 
 In `let change = TxOut {...}` we are instantiating the change output.
 It is very similar to the `spend` output, but we are now using the `const CHANGE_AMOUNT` that we defined earlier[^spend].
-This is done by setting the `script_pubkey` field to [`ScriptBuf::new_v0_p2wpkh(&wpkh)`](https://docs.rs/bitcoin/0.31.1/bitcoin/blockdata/script/struct.ScriptBuf.html#method.new_v0_p2wpkh),
+This is done by setting the `script_pubkey` field to [`ScriptBuf::new_p2wpkh(&wpkh)`](https://docs.rs/bitcoin/0.31.1/bitcoin/blockdata/script/struct.ScriptBuf.html#method.new_p2wpkh),
 which generates P2WPKH-type of script pubkey.
 
 In `let unsigned_tx = Transaction {...}` we are instantiating the transaction we want to sign and broadcast using the [`Transaction`](https://docs.rs/bitcoin/0.31.1/bitcoin/blockdata/transaction/struct.Transaction.html) struct.

--- a/cookbook/src/tx_taproot.md
+++ b/cookbook/src/tx_taproot.md
@@ -97,7 +97,7 @@ fn dummy_unspent_transaction_output<C: Verification>(
    secp: &Secp256k1<C>,
    internal_key: UntweakedPublicKey,
 ) -> (OutPoint, TxOut) {
-    let script_pubkey = ScriptBuf::new_v1_p2tr(secp, internal_key, None);
+    let script_pubkey = ScriptBuf::new_p2tr(secp, internal_key, None);
 
     let out_point = OutPoint {
         txid: Txid::all_zeros(), // Obviously invalid.
@@ -111,7 +111,7 @@ fn dummy_unspent_transaction_output<C: Verification>(
 ```
 
 `dummy_unspent_transaction_output` generates a dummy unspent transaction output (UTXO).
-This is a P2TR (`ScriptBuf::new_v1_p2tr`) UTXO.
+This is a P2TR (`ScriptBuf::new_p2tr`) UTXO.
 It takes the following arguments:
 
 - `secp` is a reference to a [`Secp256k1`](https://docs.rs/secp256k1/0.27.0/secp256k1/struct.Secp256k1.html) type.
@@ -167,7 +167,7 @@ Now we are ready for our main function that will sign a transaction that spends 
 #    secp: &Secp256k1<C>,
 #    internal_key: UntweakedPublicKey,
 # ) -> (OutPoint, TxOut) {
-#     let script_pubkey = ScriptBuf::new_v1_p2tr(secp, internal_key, None);
+#     let script_pubkey = ScriptBuf::new_p2tr(secp, internal_key, None);
 # 
 #     let out_point = OutPoint {
 #         txid: Txid::all_zeros(), // Obviously invalid.
@@ -233,10 +233,10 @@ fn main() {
     // Sign the sighash using the secp256k1 library (exported by rust-bitcoin).
     let tweaked: TweakedKeypair = keypair.tap_tweak(&secp, None);
     let msg = Message::from_digest(sighash.to_byte_array());
-    let sig = secp.sign_schnorr(&msg, &tweaked.to_inner());
+    let signature = secp.sign_schnorr(&msg, &tweaked.to_inner());
 
     // Update the witness stack.
-    let signature = bitcoin::taproot::Signature { sig, hash_ty: sighash_type };
+    let signature = bitcoin::taproot::Signature { signature, sighash_type };
     sighasher.witness_mut(input_index).unwrap().push(&signature.to_vec());
 
     // Get the signed transaction.
@@ -283,7 +283,7 @@ Inside the [`TxOut`](https://docs.rs/bitcoin/0.31.1/bitcoin/blockdata/transactio
 
 In `let change = TxOut {...}` we are instantiating the change output.
 It is very similar to the `spend` output, but we are now using the `const CHANGE_AMOUNT` that we defined earlier[^spend].
-This is done by setting the `script_pubkey` field to [`ScriptBuf::new_v1_p2tr(...)`](https://docs.rs/bitcoin/0.31.1/bitcoin/blockdata/script/struct.ScriptBuf.html#method.new_v1_p2tr),
+This is done by setting the `script_pubkey` field to [`ScriptBuf::new_p2tr(...)`](https://docs.rs/bitcoin/0.31.1/bitcoin/blockdata/script/struct.ScriptBuf.html#method.new_p2tr),
 which generates P2TR-type of script pubkey.
 
 In `let unsigned_tx = Transaction {...}` we are instantiating the transaction we want to sign and broadcast using the [`Transaction`](https://docs.rs/bitcoin/0.31.1/bitcoin/blockdata/transaction/struct.Transaction.html) struct.

--- a/cookbook/tests/Cargo.toml
+++ b/cookbook/tests/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 doc-comment = "0.3"
-bitcoin = { version = "0.31", features = ["std", "rand-std"] }
+bitcoin = { version = "0.32", features = ["std", "rand-std"] }


### PR DESCRIPTION
Upgrade the cookbook to use the latest release of `rust-bitcoin`.