### PR TITLE
fix(tx_taproot): missing hide comment

### DIFF
--- a/cookbook/src/tx_taproot.md
+++ b/cookbook/src/tx_taproot.md
@@ -144,7 +144,7 @@ Now we are ready for our main function that will sign a transaction that spends 
 # use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
 # use bitcoin::{
 #     transaction, Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
-      Txid, Witness,
+#     Txid, Witness,
 # };
 #
 # const DUMMY_UTXO_AMOUNT: Amount = Amount::from_sat(20_000_000);


### PR DESCRIPTION
There is a missing hide comment `#` in one of the `use` statements.