### PR TITLE
fix: remove nym and add storopoli as author

### DIFF
--- a/cookbook/book.toml
+++ b/cookbook/book.toml
@@ -2,7 +2,7 @@
 authors = [
     "Harshil Jani <harshiljani2002@gmail.com>",
     "Tobin C. Harding<me@tobin.cc>",
-    "Einherjar <realeinherjar@proton.me>",
+    "Jose Storopoli <jose@storopoli.io>",
 ]
 language = "en"
 multilingual = false


### PR DESCRIPTION
I am working this weekend in a new set of PSBTs multiple inputs signing cookbook.