### PR TITLE
ci: Add preview cookbook workflow

### DIFF
--- a/.github/workflows/preview-cookbook.yml
+++ b/.github/workflows/preview-cookbook.yml
@@ -1,0 +1,35 @@
+name: preview cookbook
+
+on:
+  pull_request: {}
+  workflow_dispatch: null
+
+jobs:
+  preview-cookbook:
+    runs-on: ubuntu-latest
+    permissions:
+      # For the comment in the PRs saying that the preview is ready.
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true # could be useful in the future
+          fetch-depth: 0   # we just need the latest commit
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
+
+      - name: Build mdbook
+        working-directory: ./cookbook
+        run: mdbook build
+
+      - name: Make preview available
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cookbook-preview
+          path: ./cookbook/book
+          retention-days: 8


### PR DESCRIPTION
Add a new workflow file to enable previewing the cookbook.

The main advantage here is that in order to review new contributor,
the reviewer do not need to run the code locally to render the `mdbook` output.
This is useful since not only simplifies the review workflow,
but also diminishes the effort that it takes for someone to review
a contribution; hence opening opportunities for new reviewers to join in. 

This workflow runs on pull requests and
creates a preview of the cookbook using mdBook.

The preview is then uploaded as an artifact.

It might be useful to preview a rendered version
of the cookbook.