### PR TITLE
ci: add typo checking

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,17 @@
+name: Check Typos
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+  workflow_dispatch: null
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v4
+
+    - name: Check spelling
+      uses: crate-ci/typos@master

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,16 @@
+[default]
+
+[default.extend-words]
+# NOTE: use here for false-positives
+# EXAMPLE: PSBT = "PSBT"
+
+[files]
+extend-exclude = ["site/themes/nightfall"]
+
+[type.gitignore]
+extend-glob = [".gitignore"]
+check-file = false
+
+[type.lock]
+extend-glob = ["*.lock"]
+check-file = false

--- a/cookbook/src/tx_segwit-v0.md
+++ b/cookbook/src/tx_segwit-v0.md
@@ -307,7 +307,7 @@ This is the message that we will sign.
 The [Message::from](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Message.html#impl-From%3C%26%27_%20bitcoin%3A%3Ahashes%3A%3Asha256d%3A%3AHash%3E) method takes anything that implements the promises to be a thirty two byte hash i.e., 32 bytes that came from a cryptographically secure hashing algorithm.
 
 We compute the signature `sig` by using the [`sign_ecdsa`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Secp256k1.html#method.sign_ecdsa) method.
-It takes a refence to a [`Message`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Message.html) and a reference to a [`SecretKey`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.SecretKey.html) as arguments,
+It takes a reference to a [`Message`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Message.html) and a reference to a [`SecretKey`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.SecretKey.html) as arguments,
 and returns a [`Signature`](https://docs.rs/secp256k1/0.29.0/secp256k1/ecdsa/struct.Signature.html) type.
 
 In the next step, we update the witness stack for the input we just signed by first converting the `sighash_cache` into a [`Transaction`](https://docs.rs/bitcoin/0.32.0/bitcoin/blockdata/transaction/struct.Transaction.html)
@@ -337,7 +337,7 @@ This transaction is now ready to be broadcast to the Bitcoin network.
 [^change]: Please note that the `CHANGE_AMOUNT` is not the same as the `DUMMY_UTXO_AMOUNT` minus the `SPEND_AMOUNT`.
            This is due to the fact that we need to pay a fee for the transaction.
 
-[^expect]: We will be unwraping any [`Option<T>`](https://doc.rust-lang.org/std/option)/[`Result<T, E>`](https://doc.rust-lang.org/std/result)
+[^expect]: We will be unwrapping any [`Option<T>`](https://doc.rust-lang.org/std/option)/[`Result<T, E>`](https://doc.rust-lang.org/std/result)
            with the `expect` method.
 
 [^secp]: Under the hood we are using the [`secp256k1`](https://github.com/rust-bitcoin/rust-secp256k1/) crate to generate the key pair.
@@ -346,4 +346,3 @@ This transaction is now ready to be broadcast to the Bitcoin network.
          [secp256k1](https://en.bitcoin.it/wiki/Secp256k1).
 
 [^spend]: And also we are locking the output to an address that we control:
-          the `wpkh` public key hash that we generated earlier. 

--- a/cookbook/src/tx_taproot.md
+++ b/cookbook/src/tx_taproot.md
@@ -62,7 +62,7 @@ fn senders_keys<C: Signing>(secp: &Secp256k1<C>) -> Keypair {
 This will be useful to mock a sender.
 In a real application these would be actual secrets[^secp].
 We use the `SecretKey::new` method to generate a random private key `sk`.
-We then use the [`Keypair::from_secret_key`](https://docs.rs/bitcoin/0.32.0/bitcoin/key/struct.Keypair.html#method.from_secret_key) method to instatiate a [`Keypair`](https://docs.rs/bitcoin/0.32.0/bitcoin/key/struct.Keypair.html) type,
+We then use the [`Keypair::from_secret_key`](https://docs.rs/bitcoin/0.32.0/bitcoin/key/struct.Keypair.html#method.from_secret_key) method to instantiate a [`Keypair`](https://docs.rs/bitcoin/0.32.0/bitcoin/key/struct.Keypair.html) type,
 which is a data structure that holds a keypair consisting of a secret and a public key.
 Note that `senders_keys` is generic over the [`Signing`](https://docs.rs/secp256k1/0.29.0/secp256k1/trait.Signing.html) trait.
 This is used to indicate that is an instance of `Secp256k1` and can be used for signing.
@@ -320,7 +320,7 @@ It takes the following arguments:
 
 - `input_index` is the index of the input we are signing; it is a [`usize`](https://doc.rust-lang.org/std/primitive.usize.html) type.
    We are using `0` since we only have one input.
-- `&prevouts` is a refence to the [`Prevouts`](https://docs.rs/bitcoin/0.32.0/bitcoin/sighash/enum.Prevouts.html) enum that we defined earlier.
+- `&prevouts` is a reference to the [`Prevouts`](https://docs.rs/bitcoin/0.32.0/bitcoin/sighash/enum.Prevouts.html) enum that we defined earlier.
    This is used to reference the outputs of previous transactions and also used to calculate our transaction value.
 - `annex` is an optional argument that is used to pass the annex data.
    We are not using it, so we are passing `None`.
@@ -338,7 +338,7 @@ This is a the message that we will sign.
 The [Message::from](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Message.html#impl-From%3C%26%27_%20bitcoin%3A%3Ahashes%3A%3Asha256d%3A%3AHash%3E) method takes anything that implements the promises to be a thirty two byte hash i.e., 32 bytes that came from a cryptographically secure hashing algorithm.
 
 We compute the signature `sig` by using the [`sign_schnorr`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Secp256k1.html#method.sign_schnorr) method.
-It takes a refence to a [`Message`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Message.html) and a reference to a [`Keypair`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Keypair.html) as arguments,
+It takes a reference to a [`Message`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Message.html) and a reference to a [`Keypair`](https://docs.rs/secp256k1/0.29.0/secp256k1/struct.Keypair.html) as arguments,
 and returns a [`Signature`](https://docs.rs/secp256k1/0.29.0/secp256k1/ecdsa/struct.Signature.html) type.
 
 In the next step, we update the witness stack for the input we just signed by first converting the `sighash_cache` into a [`Transaction`](https://docs.rs/bitcoin/0.32.0/bitcoin/blockdata/transaction/struct.Transaction.html)
@@ -356,7 +356,7 @@ This transaction is now ready to be broadcast to the Bitcoin network.
 [^change]: Please note that the `CHANGE_AMOUNT` is not the same as the `DUMMY_UTXO_AMOUNT` minus the `SPEND_AMOUNT`.
            This is due to the fact that we need to pay a fee for the transaction.
 
-[^expect]: We will be unwraping any [`Option<T>`](https://doc.rust-lang.org/std/option)/[`Result<T, E>`](https://doc.rust-lang.org/std/result)
+[^expect]: We will be unwrapping any [`Option<T>`](https://doc.rust-lang.org/std/option)/[`Result<T, E>`](https://doc.rust-lang.org/std/result)
            with the `expect` method.
 
 [^secp]: Under the hood we are using the [`secp256k1`](https://github.com/rust-bitcoin/rust-secp256k1/) crate to generate the key pair.


### PR DESCRIPTION
Since this is a public-facing documentation/resource repository,
we should be extra-careful and
judicious with typos.

[`typos`](https://github.com/crate-ci/typos) is a powerful source code spell checker.

I've added a CI job that runs on every PR and push to `master` (but can also be run manually with `workflow_dispatch`) that checks for typos.

I've also added a config file `.typos.toml` that deals with false positives and ignore some vendor related files and some filetypes that we don't want to check/correct for typos,
e.g. lock files.

Finally, I've also corrected a few typos that were in the codebase that typos flagged.

If you want to run yourself you can do a cargo install (or binstall) the typos-cli:

```bash
cargo install typos-cli
```

It is also available in several pkg managers,
check the installation options at the [`typos` repo](https://github.com/crate-ci/typos?tab=readme-ov-file#install)