### PR TITLE
docs: point README to docs.rs latest instead of pinned 0.32.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ find it missing please consider contributing an example or raising an issue.
 
 ## Current rust-bitcoin version
 
-This cookbook is currently based on [rust-bitcoin `v0.32.0`](https://docs.rs/bitcoin/0.32.0/bitcoin/index.html)
+This cookbook targets the current rust-bitcoin release.
+See the API docs on [docs.rs](https://docs.rs/bitcoin/latest/bitcoin/).
 
 ## License
 


### PR DESCRIPTION
Replace hardcoded link to bitcoin 0.32.0 with docs.rs/bitcoin/latest/bitcoin/ to avoid stale docs and reduce maintenance. No code changes.