### PR TITLE
cookbook: Remove multilingual config flag

### DIFF
--- a/cookbook/book.toml
+++ b/cookbook/book.toml
@@ -5,7 +5,6 @@ authors = [
     "Jose Storopoli <jose@storopoli.io>",
 ]
 language = "en"
-multilingual = false
 src = "src"
 title = "Rust Bitcoin Cookbook"
 description = "A cookbook for Rust Bitcoin development"


### PR DESCRIPTION
This makes the build fail, remove it.